### PR TITLE
Migrate to @apollo/client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.tool-versions
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,39 +231,43 @@
         }
       }
     },
-    "@apollo/react-common": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
-      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+    "@apollo/client": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.4.tgz",
+      "integrity": "sha512-lfsxKINoc11+g4NQFyKFuxszc/GlecHrxkJYvx/oWkdpscSU5bm/c+BwI/yvk1/E3yfbR7Afi9XIYrt212xrtA==",
       "requires": {
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-components": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.5.tgz",
-      "integrity": "sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.2.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.13.0",
         "prop-types": "^15.7.2",
+        "symbol-observable": "^2.0.0",
+        "terser": "^5.2.0",
         "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-hoc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.5.tgz",
-      "integrity": "sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
       },
       "dependencies": {
+        "@wry/context": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.4.tgz",
+          "integrity": "sha512-/pktJKHUXDr4D6TJqWgudOPJW2Z+Nb+bqk40jufA3uTkLbnCRKdJPiYDIa/c7mfcPH8Hr6O8zjCERpg5Sq04Zg==",
+          "requires": {
+            "tslib": "^1.14.1"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
         "hoist-non-react-statics": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -271,39 +275,51 @@
           "requires": {
             "react-is": "^16.7.0"
           }
+        },
+        "optimism": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.2.tgz",
+          "integrity": "sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==",
+          "requires": {
+            "@wry/context": "^0.5.2"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+          "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+        },
+        "terser": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+          "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.20"
+          }
         }
-      }
-    },
-    "@apollo/react-hooks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
-      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@wry/equality": "^0.1.9",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
-      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-hooks": "^3.1.5",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@apollo/react-testing": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.4.tgz",
-      "integrity": "sha512-1eKjN36UfIAnBVmfLbl12vQ/eCjTqYdaU95chGIQzT2uHd5BnasJu0z+MwXBrEs57A9WY9mFvLZxdjzQJXaacA==",
-      "dev": true,
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "fast-json-stable-stringify": "^2.0.0",
-        "tslib": "^1.10.0"
       }
     },
     "@arr/every": {
@@ -1693,6 +1709,11 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -3703,23 +3724,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
-      "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4071,130 +4075,6 @@
             "repeat-string": "^1.6.1"
           }
         }
-      }
-    },
-    "apollo-boost": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
-      "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-cache-inmemory": "^1.6.6",
-        "apollo-client": "^2.6.10",
-        "apollo-link": "^1.0.6",
-        "apollo-link-error": "^1.0.3",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
-      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-batch": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/apollo-link-batch/-/apollo-link-batch-1.1.15.tgz",
-      "integrity": "sha512-XbfQI/FNxJW9RSgJTfAl7RDFxxN77425yDtT7YgsImH4/2NQ+U4SWN6thWE3ZU1Wf7ktXd+XFa3KkenBRTybOQ==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-batch-http": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/apollo-link-batch-http/-/apollo-link-batch-http-1.2.14.tgz",
-      "integrity": "sha512-LFUmfV3OXR3Er+zSgFxPY/qUe4Wyx0HS1euJZ36RCCaDvPegr24C9OQgKFScHy91VbjRTtFUyjXXVq1xFGPMvQ==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-batch": "^1.1.15",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
-      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
       }
     },
     "append-buffer": {
@@ -21135,14 +21015,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "optimism": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
-      "requires": {
-        "@wry/context": "^0.4.0"
-      }
-    },
     "optimize-css-assets-webpack-plugin": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
@@ -23331,18 +23203,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-apollo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.5.tgz",
-      "integrity": "sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==",
-      "requires": {
-        "@apollo/react-common": "^3.1.4",
-        "@apollo/react-components": "^3.1.5",
-        "@apollo/react-hoc": "^3.1.5",
-        "@apollo/react-hooks": "^3.1.5",
-        "@apollo/react-ssr": "^3.1.5"
       }
     },
     "react-app-polyfill": {
@@ -29867,15 +29727,6 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
-      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "apollo-boost": "^0.4.9",
-    "apollo-cache-inmemory": "^1.3.5",
-    "apollo-link-batch-http": "^1.2.14",
     "bootstrap": "^4.1.3",
     "bytes": "^3.0.0",
     "classnames": "^2.2.6",
@@ -20,7 +17,7 @@
     "rc-pagination": "^3.1.15",
     "rc-slider": "^9.7.5",
     "react": "^16.13.1",
-    "react-apollo": "^3.1.3",
+    "@apollo/client": "3.2.4",
     "react-dom": "^16.13.1",
     "react-flag-icon-css": "^1.0.24",
     "react-router-dom": "^4.3.1",
@@ -42,7 +39,6 @@
   },
   "devDependencies": {
     "@adobe/jsonschema2md": "^6.1.4",
-    "@apollo/react-testing": "^3.1.3",
     "ajv-cli": "^3.0.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",

--- a/src/components/HostsForm/HostsCreation/HostsNames/HostNameInput.js
+++ b/src/components/HostsForm/HostsCreation/HostsNames/HostNameInput.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useContext, useEffect } from 'react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { get } from 'lodash'
 import { Col, FormGroup, FormControl, ControlLabel, Icon } from 'patternfly-react'
 

--- a/src/components/HostsForm/PuppetConfig/Custom/PuppetEnvSelectInput.js
+++ b/src/components/HostsForm/PuppetConfig/Custom/PuppetEnvSelectInput.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import T from 'i18n-react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { get } from 'lodash'
 import { HostsFormContext } from 'lib/Context'
 import SelectInput from 'components/HostsForm/SelectInput'

--- a/src/components/HostsForm/PuppetConfig/Custom/PuppetMasterSelectInput.js
+++ b/src/components/HostsForm/PuppetConfig/Custom/PuppetMasterSelectInput.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import T from 'i18n-react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { get } from 'lodash'
 import SelectInput from 'components/HostsForm/SelectInput'
 import { HostsFormContext } from 'lib/Context'

--- a/src/components/HostsForm/PuppetConfig/Custom/PuppetclassesSelectInput.js
+++ b/src/components/HostsForm/PuppetConfig/Custom/PuppetclassesSelectInput.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import T from 'i18n-react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { get } from 'lodash'
 import { HostsFormContext } from 'lib/Context'
 import SelectInput from 'components/HostsForm/SelectInput'

--- a/src/components/HostsForm/ServerConfig/Selects/OwnerSelectInput.js
+++ b/src/components/HostsForm/ServerConfig/Selects/OwnerSelectInput.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useContext } from 'react'
 import T from 'i18n-react'
-import { useQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/client';
 import { get } from 'lodash'
 import { HostsFormContext } from 'lib/Context'
 import SelectInput from 'components/HostsForm/SelectInput'
@@ -16,7 +16,6 @@ const OwnerSelectInput = ({...attrs}) => {
   const ownersFrom = (data) => get(data, 'currentUser.usergroups.edges', []).map(({ node: { id, name }}) => ({ id, name }))
 
   const { loading, data } = useQuery(OWNERS_QUERY, {
-    fetchPolicy: 'cache-and-network',
     onCompleted: (data) => {
       const owners = ownersFrom(data)
 

--- a/src/components/HostsForm/ServerConfig/Selects/SubnetSelectInput.js
+++ b/src/components/HostsForm/ServerConfig/Selects/SubnetSelectInput.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import T from 'i18n-react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { get } from 'lodash'
 import { HostsFormContext } from 'lib/Context'
 import SelectInput from 'components/HostsForm/SelectInput'

--- a/src/containers/DashboardContainer/__tests__/index_test.js
+++ b/src/containers/DashboardContainer/__tests__/index_test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MemoryRouter } from 'react-router-dom'
-import { MockedProvider } from '@apollo/react-testing'
+import { MockedProvider } from '@apollo/client/testing'
 import HOSTS_QUERY_MOCK from 'graphql/queries/__mocks__/hosts_mock';
 import DashboardContainer from 'containers/DashboardContainer';
 

--- a/src/containers/DashboardContainer/index.js
+++ b/src/containers/DashboardContainer/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import T from 'i18n-react';
-import { Query } from 'react-apollo';
+import { Query } from '@apollo/client/react/components';
 import { Spinner } from 'patternfly-react';
 
 import Notification from 'components/Notification';

--- a/src/containers/HostContainer/__tests__/index_test.js
+++ b/src/containers/HostContainer/__tests__/index_test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import wait from 'waait';
 import { MemoryRouter } from 'react-router-dom'
-import { MockedProvider } from '@apollo/react-testing'
+import { MockedProvider } from '@apollo/client/testing'
 import HOST_QUERY_MOCK from 'graphql/queries/__mocks__/host_mock';
 import HostContainer from 'containers/HostContainer';
 

--- a/src/containers/HostContainer/index.js
+++ b/src/containers/HostContainer/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import T from 'i18n-react';
-import { Query } from 'react-apollo';
+import { Query } from '@apollo/client/react/components';
 import { Spinner } from 'patternfly-react';
 import Host from 'components/Host';
 import HOST_QUERY from 'graphql/queries/host';

--- a/src/containers/NewHostContainer/__tests__/index_test.js
+++ b/src/containers/NewHostContainer/__tests__/index_test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import wait from 'waait'
 import { MemoryRouter } from 'react-router-dom'
-import { MockedProvider } from '@apollo/react-testing'
+import { MockedProvider } from '@apollo/client/testing'
 import NewHostContainer from 'containers/NewHostContainer'
 
 import COMPUTE_RESOURCE_QUERY_MOCK from 'graphql/queries/__mocks__/computeResource_mock'
@@ -40,20 +40,13 @@ test('Mounted NewHostContainer', async () => {
   const subnetSelect = wrapper.find('Select[placeholder="hosts_form.placeholders.subnet_id"]')
   subnetSelect.instance().selectValue({ value: 'MDE6U3VibmV0LTE=', label: 'subnet' })
 
-  await wait()
-  wrapper.update()
-
   const customPuppetConfigButton = wrapper.find('button').findWhere(x => x.text() === 'hosts_form.puppet_config.default.link')
   customPuppetConfigButton.first().simulate('click')
 
-  await wait()
   wrapper.update()
 
   const puppetEnvIdSelect = wrapper.find('Select[placeholder="hosts_form.placeholders.puppet_env_id"]')
   puppetEnvIdSelect.instance().selectValue({ value: 'MDE6RW52aXJvbm1lbnQtMA==', label: 'env2' })
-
-  await wait()
-  wrapper.update()
 
   const puppetclassIdsSelect = wrapper.find('Select[placeholder="hosts_form.placeholders.puppetclass_ids"]')
   puppetclassIdsSelect.instance().selectValue({ value: 'MDE6UHVwcGV0Y2xhc3MtMg==', label: 'ppclass2' })

--- a/src/containers/NewHostContainer/index.js
+++ b/src/containers/NewHostContainer/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { withApollo } from 'react-apollo';
+import { withApollo } from '@apollo/client/react/hoc';
 import { withRouter } from 'react-router-dom'
 import { Button, Col, Grid, Row } from 'patternfly-react';
 import { flowRight } from 'lodash';

--- a/src/graphql/client.js
+++ b/src/graphql/client.js
@@ -1,8 +1,6 @@
-import { ApolloClient } from 'apollo-boost';
-import { ApolloLink, from } from 'apollo-link';
-import { BatchHttpLink } from 'apollo-link-batch-http';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { onError } from 'apollo-link-error';
+import { ApolloClient, InMemoryCache, ApolloLink, from } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
+import { BatchHttpLink } from '@apollo/client/link/batch-http';
 
 const authMiddleware = new ApolloLink((operation, forward) => {
   // add the authorization to the headers

--- a/src/graphql/queries/__mocks__/hostnamesAlreadyTaken_mock.js
+++ b/src/graphql/queries/__mocks__/hostnamesAlreadyTaken_mock.js
@@ -5,8 +5,8 @@ export default [
     request: {
       query: HOSTNAMES_ALREADY_TAKEN_QUERY,
       variables: {
-        first: 10,
-        last: 10,
+        first: 1,
+        last: 1,
         search: 'name=project-role-01.development.example.com'
       }
     },

--- a/src/graphql/queries/__mocks__/puppetMasters_mock.js
+++ b/src/graphql/queries/__mocks__/puppetMasters_mock.js
@@ -5,7 +5,7 @@ export default [
     request: {
       query: PUPPETMASTERS_QUERY,
       variables: {
-        search: 'feature = Puppet and location = DE-KA-LAN'
+        search: 'feature = Puppet and location = LAN'
       }
     },
     result: {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import '../node_modules/patternfly-react/dist/css/patternfly-react.css';
 import 'react-select/dist/react-select.css';
 
 import T from 'i18n-react';
-import { ApolloProvider } from 'react-apollo'
+import { ApolloProvider } from '@apollo/client'
 import GraphqlClient from './graphql/client'
 
 import enJSON from './locales/en.json'


### PR DESCRIPTION
> Apollo Client is now distributed as the `@apollo/client` package (previous versions are distributed as `apollo-client`).

[Migrating to Apollo Client 3.0](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/)

Closes #25 