### PR TITLE
Drop support for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       max-parallel: 2
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This README outlines the details of collaborating on this React.js application.
 | --------------- |
 | >= 1.24         |
 
-LISA is known to work with Node version >= 12 and <= 16.
+LISA is known to work with Node version >= 14 and <= 16.
 
 ## Installation
 


### PR DESCRIPTION
Security support for node 12 ended on April 30, 2022