### PR TITLE
Fix regex to avoid duplicate plugins

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -5,7 +5,7 @@ const areWeTestingWithJest = process.env.JEST_WORKER_ID !== undefined
 const pluginsExtensions = []
 const pluginsLocales = {}
 const importAll = (r) => { return r.keys().map(r) }
-const modules = areWeTestingWithJest ? [] : importAll(require.context('./plugins', false, /\.js$/))
+const modules = areWeTestingWithJest ? [] : importAll(require.context('./plugins', false, /plugins\/.*\.js$/))
 
 function registerPlugin({ default: { extensions, locales }}) {
   extensions.map(ext => pluginsExtensions.push(ext))


### PR DESCRIPTION
before:

```
['./lisa-plugin.js', 'plugins/lisa-plugin.js']
```

after:

```
['plugins/lisa-plugin.js']
```
